### PR TITLE
Update repository URLs and API key format examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install -g @msgcore/cli
 ```bash
 # Configure CLI (stores in ~/.msgcore/config.json with secure permissions)
 msgcore config set apiUrl https://api.msgcore.dev
-msgcore config set apiKey gk_live_your_api_key_here
+msgcore config set apiKey msc_live_your_api_key_here
 msgcore config set defaultProject my-project
 
 # Verify configuration
@@ -32,7 +32,7 @@ msgcore messages send --target "platform-id:user:123" --text "Hello!"
 ```bash
 # Set environment variables (override config file)
 export MSGCORE_API_URL="https://api.msgcore.dev"
-export MSGCORE_API_KEY="gk_live_your_api_key_here"
+export MSGCORE_API_KEY="msc_live_your_api_key_here"
 export MSGCORE_DEFAULT_PROJECT="my-project"
 
 # Use CLI
@@ -221,7 +221,7 @@ msgcore webhooks get --webhookId "webhook-123"
 ```bash
 # Set configuration values
 msgcore config set apiUrl https://api.msgcore.dev
-msgcore config set apiKey gk_live_your_api_key_here
+msgcore config set apiKey msc_live_your_api_key_here
 msgcore config set defaultProject my-project
 msgcore config set outputFormat json
 
@@ -244,7 +244,7 @@ Stored in `~/.msgcore/config.json` with **secure permissions (600)**:
 ```json
 {
   "apiUrl": "https://api.msgcore.dev",
-  "apiKey": "gk_live_your_api_key_here",
+  "apiKey": "msc_live_your_api_key_here",
   "defaultProject": "my-project",
   "outputFormat": "table"
 }
@@ -263,7 +263,7 @@ Environment variables have **highest priority**:
 
 ```bash
 export MSGCORE_API_URL="https://api.msgcore.dev"
-export MSGCORE_API_KEY="gk_live_your_api_key_here"
+export MSGCORE_API_KEY="msc_live_your_api_key_here"
 export MSGCORE_JWT_TOKEN="your-jwt-token"  # Alternative to API key
 export MSGCORE_DEFAULT_PROJECT="my-project"
 export MSGCORE_OUTPUT_FORMAT="json"        # or "table"
@@ -304,7 +304,7 @@ echo $RESULT | jq '.jobId'
 ## Links
 
 - [Documentation](https://docs.msgcore.dev)
-- [GitHub](https://github.com/filipexyz/msgcore-cli)
+- [GitHub](https://github.com/msgcore/msgcore-cli)
 - [npm](https://www.npmjs.com/package/@msgcore/cli)
 - [Discord Community](https://discord.gg/bQPsvycW)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msgcore/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Official CLI for MsgCore universal messaging gateway",
   "main": "dist/index.js",
   "bin": {
@@ -33,10 +33,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/filipexyz/msgcore-cli.git"
+    "url": "https://github.com/msgcore/msgcore-cli.git"
   },
-  "homepage": "https://github.com/filipexyz/msgcore-cli",
+  "homepage": "https://github.com/msgcore/msgcore-cli",
   "bugs": {
-    "url": "https://github.com/filipexyz/msgcore-cli/issues"
+    "url": "https://github.com/msgcore/msgcore-cli/issues"
   }
 }

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -112,7 +112,7 @@ const CONTRACTS = [
       "SentMessageListResponse": "export interface SentMessageListResponse {\n  messages: SentMessageResponse[];\n  pagination: {\n    total: number;\n    limit: number;\n    offset: number;\n    hasMore: boolean;\n  };\n}",
       "SentMessageResponse": "export interface SentMessageResponse {\n  id: string;\n  platform: string;\n  jobId: string | null;\n  providerMessageId: string | null;\n  targetChatId: string;\n  targetUserId: string | null;\n  targetType: string;\n  messageText: string | null;\n  messageContent: Record<string, unknown> | null;\n  status: string;\n  errorMessage: string | null;\n  sentAt: Date | null;\n  createdAt: Date;\n}",
       "SignupDto": "export interface SignupDto {\n  email: string;\n  password: string;\n  name?: string;\n}",
-      "SupportedPlatformsResponse": "export interface SupportedPlatformsResponse {\n  platforms: Array<{\n    name: string;\n    displayName: string;\n    connectionType: string;\n    features: {\n      supportsWebhooks: boolean;\n      supportsPolling: boolean;\n      supportsWebSocket: boolean;\n    };\n    credentials: {\n      required: string[];\n      optional: string[];\n      example: Record<string, any>;\n    } | null;\n  }>;\n}",
+      "SupportedPlatformsResponse": "export interface SupportedPlatformsResponse {\n  platforms: Array<{\n    name: string;\n    displayName: string;\n    connectionType: string;\n    features: {\n      supportsWebhooks: boolean;\n      supportsPolling: boolean;\n      supportsWebSocket: boolean;\n    };\n    capabilities: Array<{\n      capability: string;\n      limitations?: string;\n    }>;\n    credentials: {\n      required: string[];\n      optional: string[];\n      example: Record<string, any>;\n    } | null;\n  }>;\n}",
       "TargetDto": "export interface TargetDto {\n  platformId: string;\n  type: TargetType;\n  id: string;\n}",
       "TargetType": "export type TargetType = 'user' | 'channel' | 'group';",
       "UpdateIdentityDto": "export interface UpdateIdentityDto {\n  displayName?: string;\n  email?: string;\n  metadata?: Record<string, any>;\n}",
@@ -2493,7 +2493,7 @@ class McpStdioServer {
       result: {
         protocolVersion: '2024-11-05',
         capabilities: { tools: {} },
-        serverInfo: { name: 'msgcore-mcp-cli', version: '1.0.0' },
+        serverInfo: { name: 'msgcore-mcp-cli', version: '1.0.1' },
       },
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const program = new Command();
 program
   .name('msgcore')
   .description('MsgCore Universal Messaging Gateway CLI')
-  .version('1.0.0');
+  .version('1.0.1');
 
 // Config command
 const config = new Command('config');


### PR DESCRIPTION
## Summary

Updates repository URLs from personal namespace to official msgcore organization and standardizes API key examples to use the new  prefix format.

**Version**: v1.0.1
**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)

### Changes

- **Repository URLs**: Updated from  to  in package.json and README
- **API Key Format**: Changed example API keys from  prefix to  prefix throughout documentation  
- **Platform Capabilities**: Added capabilities array to SupportedPlatformsResponse interface
- **Version Bump**: Updated to v1.0.1 across all version references

### Updated Examples



### Repository Links

All GitHub links now point to the official organization:
- Repository: https://github.com/msgcore/msgcore-cli
- Issues: https://github.com/msgcore/msgcore-cli/issues
