### PR TITLE
chore: bump version to 1.0.2 and fix MCP JSON Schema compliance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msgcore/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official CLI for MsgCore universal messaging gateway",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -2411,7 +2411,10 @@ class McpStdioServer {
       }
     }
 
-    if (required.length > 0) inputSchema.required = required;
+    if (required.length > 0) {
+      // Deduplicate required array for JSON Schema 2020-12 compliance
+      inputSchema.required = [...new Set(required)];
+    }
 
     return {
       name: `msgcore_${contract.contractMetadata.command.replace(/\s+/g, '_')}`,
@@ -2493,7 +2496,7 @@ class McpStdioServer {
       result: {
         protocolVersion: '2024-11-05',
         capabilities: { tools: {} },
-        serverInfo: { name: 'msgcore-mcp-cli', version: '1.0.1' },
+        serverInfo: { name: 'msgcore-mcp-cli', version: '1.0.2' },
       },
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const program = new Command();
 program
   .name('msgcore')
   .description('MsgCore Universal Messaging Gateway CLI')
-  .version('1.0.1');
+  .version('1.0.2');
 
 // Config command
 const config = new Command('config');


### PR DESCRIPTION
# MsgCore CLI v1.0.2

This release updates the CLI to version **1.0.2** with an important MCP (Model Context Protocol) JSON Schema compliance fix.

**Source**: [MsgCore Backend](https://github.com/msgcore/msgcore)

## Changes

### 🔧 JSON Schema Compliance Fix

- **Fixed MCP JSON Schema validation** - Added deduplication for required arrays in JSON Schema generation to ensure compliance with JSON Schema 2020-12 specification
- **Impact**: Resolves potential schema validation issues with MCP tools that have duplicate required properties

### 📦 Version Updates

- **CLI version**: Updated from  →  in:
  - 
  -  (CLI program version)
  -  (MCP server info)

## Technical Details

The fix addresses a specific edge case where MCP JSON Schema generation could produce duplicate entries in the  array, which violates JSON Schema 2020-12 specification:



## What's MCP?

MCP (Model Context Protocol) integration allows the MsgCore CLI to function as an AI agent tool, enabling AI systems to send messages through the universal messaging gateway programmatically.
